### PR TITLE
Add reference to electrodes table in units

### DIFF
--- a/src/dicarlo_lab_to_nwb/conversion/convert_session.py
+++ b/src/dicarlo_lab_to_nwb/conversion/convert_session.py
@@ -274,7 +274,7 @@ if __name__ == "__main__":
     # assert stimuli_folder.is_dir(), f"Stimuli folder not found: {stimuli_folder}"
 
     output_dir_path = Path.home() / "conversion_nwb"
-    stub_test = True
+    stub_test = False
     verbose = True
     add_thresholding_events = True
     add_psth = True

--- a/src/dicarlo_lab_to_nwb/conversion/convert_session.py
+++ b/src/dicarlo_lab_to_nwb/conversion/convert_session.py
@@ -274,7 +274,7 @@ if __name__ == "__main__":
     # assert stimuli_folder.is_dir(), f"Stimuli folder not found: {stimuli_folder}"
 
     output_dir_path = Path.home() / "conversion_nwb"
-    stub_test = False
+    stub_test = True
     verbose = True
     add_thresholding_events = True
     add_psth = True

--- a/src/dicarlo_lab_to_nwb/conversion/pipeline.py
+++ b/src/dicarlo_lab_to_nwb/conversion/pipeline.py
@@ -531,7 +531,15 @@ def write_thresholding_events_to_nwb(
             "Spike times detected using thresholding with DiCarlo lab pipeline and the following parameters: \n "
             f"{thresholindg_pipeline_kwargs}"
         )
-        add_sorting(nwbfile=nwbfile, sorting=sorting, units_description=units_description)
+
+        number_of_units = sorting.get_num_units()
+        unit_electrode_indices = [[i] for i in range(number_of_units)]
+        add_sorting(
+            nwbfile=nwbfile,
+            sorting=sorting,
+            units_description=units_description,
+            unit_electrode_indices=unit_electrode_indices,
+        )
 
         if append:
             io.write(nwbfile)


### PR DESCRIPTION
This will close #25.

Units already had the channel name as unit name but this will make the link more explicit. I tested this like this:

![image](https://github.com/user-attachments/assets/96a96d28-3025-418f-b152-8e1910bc45de)
