### PR TITLE
Add script to transform `SFM_foveal_videos_2` data

### DIFF
--- a/src/dicarlo_lab_to_nwb/conversion/conversion_sfm_videos_session.py
+++ b/src/dicarlo_lab_to_nwb/conversion/conversion_sfm_videos_session.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+
+data_folder = Path("/media/heberto/One Touch/DiCarlo-CN-data-share")
+
+image_set_name = "SFM_foveal_videos_2"
+
+stimulus_data_folder_path = data_folder / image_set_name
+assert stimulus_data_folder_path.exists(), f"{stimulus_data_folder_path} does not exist"
+
+session_date = "20240715"
+session_time = "144848"
+
+session_date = "20240716"
+session_time = "142554"
+
+session_date = "20240717"
+session_time = "151839"
+
+# Normalizers
+session_date = "20240715"
+session_time = "144848"
+normalizer = True
+
+subject = "Apollo"  # Confirm this?
+
+session_folder_path = stimulus_data_folder_path / session_date
+
+assert session_folder_path.exists(), f"{session_folder_path} does not exist"
+
+if normalizer:
+    session_data_folder = session_folder_path / f"{image_set_name}_{session_date[2:]}_{session_time}"
+else:
+    sesssion_data_folder = session_folder_path / f"normalizers_{session_date[2:]}_{session_time}_raw"
+assert session_data_folder.exists(), f"{session_data_folder} does not exist"
+
+session_data_intan_file_path = session_data_folder / "info.rhd"
+assert session_data_intan_file_path.exists(), f"{session_data_intan_file_path} does not exist"
+
+session_data_mworks_processed_file_path = (
+    session_data_folder / f"rig1-SFM.foveal.videos_2_rig_1-{session_date}-{session_time}_mwk.csv"
+)
+session_data_mworks_processed_file_path = [path for path in session_data_folder.iterdir() if path.suffix == ".csv"][0]
+assert session_data_mworks_processed_file_path.exists(), f"{session_data_mworks_processed_file_path} does not exist"
+
+from dicarlo_lab_to_nwb.conversion.convert_session import convert_session_to_nwb
+
+session_metadata = {
+    "image_set_name": image_set_name,
+    "session_date": session_date,
+    "session_time": session_time,
+    "subject": subject,
+}
+
+intan_file_path = session_data_intan_file_path
+mworks_processed_file_path = session_data_mworks_processed_file_path
+
+stimuli_folder = Path(
+    "/media/heberto/One Touch/DiCarlo-CN-data-share/StimulusSets/SFM_foveal_videos_2/stimuli/SFM_videos/"
+)
+
+output_dir_path = Path.home() / "conversion_nwb"
+stub_test = False
+verbose = True
+add_thresholding_events = True
+add_psth = True
+stimuli_are_video = True
+
+thresholindg_pipeline_kwargs = {
+    "f_notch": 60.0,  # Frequency for the notch filter
+    "bandwidth": 10.0,  # Bandwidth for the notch filter
+    "f_low": 300.0,  # Low cutoff frequency for the bandpass filter
+    "f_high": 6000.0,  # High cutoff frequency for the bandpass filter
+    "noise_threshold": 3,  # Threshold for detection in the thresholding algorithm
+}
+
+# Ten bins starting 200 ms before the stimulus and spanning 400 ms
+psth_kwargs = {"bins_span_milliseconds": 400, "num_bins": 10, "milliseconds_from_event_to_first_bin": -200.0}
+
+
+convert_session_to_nwb(
+    session_metadata=session_metadata,
+    intan_file_path=intan_file_path,
+    mworks_processed_file_path=mworks_processed_file_path,
+    stimuli_folder=stimuli_folder,
+    thresholindg_pipeline_kwargs=thresholindg_pipeline_kwargs,
+    psth_kwargs=psth_kwargs,
+    output_dir_path=output_dir_path,
+    stub_test=stub_test,
+    verbose=verbose,
+    add_thresholding_events=add_thresholding_events,
+    add_psth=add_psth,
+    stimuli_are_video=stimuli_are_video,
+)

--- a/src/dicarlo_lab_to_nwb/conversion/conversion_sfm_videos_session.py
+++ b/src/dicarlo_lab_to_nwb/conversion/conversion_sfm_videos_session.py
@@ -1,65 +1,19 @@
 from pathlib import Path
 
+from dicarlo_lab_to_nwb.conversion.convert_session import convert_session_to_nwb
+
 data_folder = Path("/media/heberto/One Touch/DiCarlo-CN-data-share")
+stimuli_folder = data_folder / "StimulusSets/SFM_foveal_videos_2/stimuli/SFM_videos/"
 
-image_set_name = "SFM_foveal_videos_2"
-
-stimulus_data_folder_path = data_folder / image_set_name
+project_name = "SFM_foveal_videos_2"
+stimulus_data_folder_path = data_folder / project_name
 assert stimulus_data_folder_path.exists(), f"{stimulus_data_folder_path} does not exist"
 
 session_date = "20240715"
-session_time = "144848"
-
-session_date = "20240716"
-session_time = "142554"
-
-session_date = "20240717"
-session_time = "151839"
-
-# Normalizers
-session_date = "20240715"
-session_time = "144848"
-normalizer = True
-
 subject = "Apollo"  # Confirm this?
 
-session_folder_path = stimulus_data_folder_path / session_date
-
-assert session_folder_path.exists(), f"{session_folder_path} does not exist"
-
-if normalizer:
-    session_data_folder = session_folder_path / f"{image_set_name}_{session_date[2:]}_{session_time}"
-else:
-    sesssion_data_folder = session_folder_path / f"normalizers_{session_date[2:]}_{session_time}_raw"
-assert session_data_folder.exists(), f"{session_data_folder} does not exist"
-
-session_data_intan_file_path = session_data_folder / "info.rhd"
-assert session_data_intan_file_path.exists(), f"{session_data_intan_file_path} does not exist"
-
-session_data_mworks_processed_file_path = (
-    session_data_folder / f"rig1-SFM.foveal.videos_2_rig_1-{session_date}-{session_time}_mwk.csv"
-)
-session_data_mworks_processed_file_path = [path for path in session_data_folder.iterdir() if path.suffix == ".csv"][0]
-assert session_data_mworks_processed_file_path.exists(), f"{session_data_mworks_processed_file_path} does not exist"
-
-from dicarlo_lab_to_nwb.conversion.convert_session import convert_session_to_nwb
-
-session_metadata = {
-    "image_set_name": image_set_name,
-    "session_date": session_date,
-    "session_time": session_time,
-    "subject": subject,
-}
-
-intan_file_path = session_data_intan_file_path
-mworks_processed_file_path = session_data_mworks_processed_file_path
-
-stimuli_folder = Path(
-    "/media/heberto/One Touch/DiCarlo-CN-data-share/StimulusSets/SFM_foveal_videos_2/stimuli/SFM_videos/"
-)
-
 output_dir_path = Path.home() / "conversion_nwb"
-stub_test = False
+stub_test = True
 verbose = True
 add_thresholding_events = True
 add_psth = True
@@ -76,18 +30,50 @@ thresholindg_pipeline_kwargs = {
 # Ten bins starting 200 ms before the stimulus and spanning 400 ms
 psth_kwargs = {"bins_span_milliseconds": 400, "num_bins": 10, "milliseconds_from_event_to_first_bin": -200.0}
 
+# This is the ground truth time column for the stimuli in the mworks csv file
+ground_truth_time_column = "samp_on_us"
 
-convert_session_to_nwb(
-    session_metadata=session_metadata,
-    intan_file_path=intan_file_path,
-    mworks_processed_file_path=mworks_processed_file_path,
-    stimuli_folder=stimuli_folder,
-    thresholindg_pipeline_kwargs=thresholindg_pipeline_kwargs,
-    psth_kwargs=psth_kwargs,
-    output_dir_path=output_dir_path,
-    stub_test=stub_test,
-    verbose=verbose,
-    add_thresholding_events=add_thresholding_events,
-    add_psth=add_psth,
-    stimuli_are_video=stimuli_are_video,
-)
+
+session_folder_path = stimulus_data_folder_path / session_date
+folders_in_session_date = [folder for folder in session_folder_path.iterdir() if folder.is_dir()]
+session_data_folder_path = next(path for path in folders_in_session_date if project_name in path.name)
+normalizers = [folder for folder in folders_in_session_date if "normalizers" in folder.name]
+
+folder_paths_to_convert = [session_data_folder_path] + normalizers
+
+for folder_with_data_path in folder_paths_to_convert:
+    intan_file_path = folder_with_data_path / "info.rhd"
+    assert intan_file_path.exists(), f"{intan_file_path} does not exist"
+
+    # This is a csv file that contains stimuli time
+    mworks_processed_file_path = [path for path in folder_with_data_path.iterdir() if path.suffix == ".csv"][0]
+    assert mworks_processed_file_path.exists(), f"{mworks_processed_file_path} does not exist"
+
+    # Folders are named {something}_{session_date}_{session_time}
+    session_time = folder_with_data_path.name.split("_")[-1]
+
+    is_normalizer = "normalizer" in folder_with_data_path.name
+    type_of_data = "session_data" if not is_normalizer else "normalizer_data"
+    session_metadata = {
+        "project_name": project_name,
+        "session_date": session_date,
+        "session_time": session_time,
+        "subject": subject,
+        "type_of_data": type_of_data,
+    }
+
+    convert_session_to_nwb(
+        session_metadata=session_metadata,
+        intan_file_path=intan_file_path,
+        mworks_processed_file_path=mworks_processed_file_path,
+        stimuli_folder=stimuli_folder,
+        thresholindg_pipeline_kwargs=thresholindg_pipeline_kwargs,
+        psth_kwargs=psth_kwargs,
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+        verbose=verbose,
+        add_thresholding_events=add_thresholding_events,
+        add_psth=add_psth,
+        stimuli_are_video=stimuli_are_video,
+        ground_truth_time_column=ground_truth_time_column,
+    )

--- a/src/dicarlo_lab_to_nwb/conversion/convert_session.py
+++ b/src/dicarlo_lab_to_nwb/conversion/convert_session.py
@@ -39,6 +39,7 @@ def convert_session_to_nwb(
     stimuli_are_video: bool = False,
     thresholindg_pipeline_kwargs: dict = None,
     psth_kwargs: dict = None,
+    ground_truth_time_column: str = "samp_on_us",
 ):
     if verbose:
         total_start = time.time()
@@ -47,18 +48,22 @@ def convert_session_to_nwb(
     if output_dir_path is None:
         output_dir_path = Path.home() / "conversion_nwb"
 
-    image_set_name = session_metadata["image_set_name"]
+    project_name = session_metadata["project_name"]
     session_date = session_metadata["session_date"]
     session_time = session_metadata["session_time"]
     subject = session_metadata["subject"]
+    type_of_data = session_metadata.get("type_of_data", "")
 
     output_dir_path = Path(output_dir_path)
     if stub_test:
         output_dir_path = output_dir_path / "nwb_stub"
     output_dir_path.mkdir(parents=True, exist_ok=True)
 
-    session_id = f"{subject}_{session_date}_{session_time}"
+    session_id = f"{subject}_{project_name}_tresholded_{session_date}_{session_time}_{type_of_data}"
     nwbfile_path = output_dir_path / f"{session_id}.nwb"
+
+    if verbose:
+        print(f"Converting session: {session_id}")
 
     conversion_options = dict()
 
@@ -84,7 +89,7 @@ def convert_session_to_nwb(
         stimuli_interface = StimuliVideoInterface(
             file_path=mworks_processed_file_path,
             folder_path=stimuli_folder,
-            image_set_name=image_set_name,
+            image_set_name=project_name,
             # video_copy_path=output_dir_path / "videos",
             video_copy_path=None,  # Add a path if videos should be copied
             verbose=verbose,
@@ -93,10 +98,11 @@ def convert_session_to_nwb(
         stimuli_interface = StimuliImagesInterface(
             file_path=mworks_processed_file_path,
             folder_path=stimuli_folder,
-            image_set_name=image_set_name,
+            image_set_name=project_name,
             verbose=verbose,
         )
 
+    conversion_options["Stimuli"] = dict(stub_test=stub_test, ground_truth_time_column=ground_truth_time_column)
     # Build the converter pipe with the previously defined data interfaces
     data_interfaces_dict = {
         "Recording": intan_recording_interface,
@@ -113,6 +119,7 @@ def convert_session_to_nwb(
     # Add datetime to conversion
     metadata = converter_pipe.get_metadata()
     metadata["NWBFile"]["session_start_time"] = session_start_time
+    metadata["session_id"] = session_id
 
     # Update default metadata with the editable in the corresponding yaml file
     editable_metadata_path = Path(__file__).parent / "metadata.yaml"
@@ -223,86 +230,3 @@ def convert_session_to_nwb(
             print(f"Total script took {total_scrip_time / 60:.2f} minutes")
         else:
             print(f"Total script took {total_scrip_time / 60 / 60:.2f} hours")
-
-
-if __name__ == "__main__":
-
-    image_set_name = "domain-transfer-2023"
-    subject = "pico"
-    session_date = "20230215"
-    session_time = "161322"
-
-    # This one has a jump in time
-    session_date = "20230214"
-    session_time = "140610"
-
-    # Third one
-    # session_date = "20230216"
-    # session_time = "150919"
-
-    # Fourth one
-    # session_date = "20230221"
-    # session_time = "130510"
-
-    # Video one (does not have intan)
-    # image_set_name = "Co3D"
-    # subject = "pico"
-    # session_date = "230627"
-    # session_time = "114317"
-
-    data_folder = Path("/media/heberto/One Touch/DiCarlo-CN-data-share")
-    assert data_folder.is_dir(), f"Data directory not found: {data_folder}"
-
-    session_metadata = {
-        "image_set_name": image_set_name,
-        "session_date": session_date,
-        "session_time": session_time,
-        "subject": subject,
-    }
-
-    intan_file_path = locate_intan_file_path(data_folder=data_folder, **session_metadata)
-
-    mworks_processed_file_path = locate_mworks_processed_file_path(
-        data_folder=data_folder,
-        image_set_name=image_set_name,
-        subject=subject,
-        session_date=session_date,
-        session_time=session_time,
-    )
-
-    stimuli_folder = data_folder / "StimulusSets" / "RSVP-domain_transfer" / "images"
-    # stimuli_folder = data_folder / "StimulusSets" / "Co3D" / "videos_mworks"
-    # assert stimuli_folder.is_dir(), f"Stimuli folder not found: {stimuli_folder}"
-
-    output_dir_path = Path.home() / "conversion_nwb"
-    stub_test = True
-    verbose = True
-    add_thresholding_events = True
-    add_psth = True
-
-    thresholindg_pipeline_kwargs = {
-        "f_notch": 60.0,  # Frequency for the notch filter
-        "bandwidth": 10.0,  # Bandwidth for the notch filter
-        "f_low": 300.0,  # Low cutoff frequency for the bandpass filter
-        "f_high": 6000.0,  # High cutoff frequency for the bandpass filter
-        "noise_threshold": 3,  # Threshold for detection in the thresholding algorithm
-    }
-
-    # Ten bins starting 200 ms before the stimulus and spanning 400 ms
-    psth_kwargs = {"bins_span_milliseconds": 400, "num_bins": 10, "milliseconds_from_event_to_first_bin": -200.0}
-
-    from dicarlo_lab_to_nwb.conversion.convert_session import convert_session_to_nwb
-
-    convert_session_to_nwb(
-        session_metadata=session_metadata,
-        intan_file_path=intan_file_path,
-        mworks_processed_file_path=mworks_processed_file_path,
-        stimuli_folder=stimuli_folder,
-        thresholindg_pipeline_kwargs=thresholindg_pipeline_kwargs,
-        psth_kwargs=psth_kwargs,
-        output_dir_path=output_dir_path,
-        stub_test=stub_test,
-        verbose=verbose,
-        add_thresholding_events=add_thresholding_events,
-        add_psth=add_psth,
-    )

--- a/src/dicarlo_lab_to_nwb/conversion/convert_session.py
+++ b/src/dicarlo_lab_to_nwb/conversion/convert_session.py
@@ -85,7 +85,8 @@ def convert_session_to_nwb(
             file_path=mworks_processed_file_path,
             folder_path=stimuli_folder,
             image_set_name=image_set_name,
-            video_copy_path=output_dir_path / "videos",
+            # video_copy_path=output_dir_path / "videos",
+            video_copy_path=None,  # Add a path if videos should be copied
             verbose=verbose,
         )
     else:

--- a/src/dicarlo_lab_to_nwb/conversion/stimuli_interface.py
+++ b/src/dicarlo_lab_to_nwb/conversion/stimuli_interface.py
@@ -131,7 +131,7 @@ class StimuliVideoInterface(BaseDataInterface):
 
         stimuli_presented = mwkorks_df.stimulus_presented.values
 
-        file_path_list = [self.stimuli_folder / f"{stimuli_number + 1}.mp4" for stimuli_number in stimuli_presented]
+        file_path_list = [self.stimuli_folder / f"{stimuli_number}.mp4" for stimuli_number in stimuli_presented]
         missing_file_path = [file_path for file_path in file_path_list if not file_path.is_file()]
         assert len(missing_file_path) == 0, f"Missing files: {missing_file_path}"
 

--- a/src/dicarlo_lab_to_nwb/conversion/stimuli_interface.py
+++ b/src/dicarlo_lab_to_nwb/conversion/stimuli_interface.py
@@ -41,11 +41,21 @@ class StimuliImagesInterface(BaseDataInterface):
 
         return metadata
 
-    def add_to_nwbfile(self, nwbfile: NWBFile, metadata: dict):
+    def add_to_nwbfile(
+        self,
+        nwbfile: NWBFile,
+        metadata: dict,
+        stub_test: bool = False,
+        ground_truth_time_column: str = "samp_on_us",
+    ):
         dtype = {"stimulus_presented": np.uint32, "fixation_correct": bool}
         mwkorks_df = pd.read_csv(self.file_path, dtype=dtype)
 
-        ground_truth_time_column = "samp_on_us"
+        if stub_test:
+            mwkorks_df = mwkorks_df.iloc[:100]
+
+        columns = mwkorks_df.columns
+        assert ground_truth_time_column in columns, f"Column {ground_truth_time_column} not found in {columns}"
         image_presentation_time_seconds = mwkorks_df[ground_truth_time_column] / 1e6
         stimulus_ids = mwkorks_df["stimulus_presented"]
 
@@ -122,13 +132,23 @@ class StimuliVideoInterface(BaseDataInterface):
 
         self.verbose = verbose
 
-    def add_to_nwbfile(self, nwbfile: NWBFile, metadata: dict):
+    def add_to_nwbfile(
+        self,
+        nwbfile: NWBFile,
+        metadata: dict,
+        stub_test: bool = False,
+        ground_truth_time_column: str = "samp_on_us",
+    ):
         dtype = {"stimulus_presented": np.uint32, "fixation_correct": bool}
         mwkorks_df = pd.read_csv(self.file_path, dtype=dtype)
 
-        ground_truth_time_column = "samp_on_us"
-        image_presentation_time_seconds = mwkorks_df[ground_truth_time_column].values / 1e6
+        if stub_test:
+            mwkorks_df = mwkorks_df.iloc[:100]
 
+        columns = mwkorks_df.columns
+        assert ground_truth_time_column in columns, f"Column {ground_truth_time_column} not found in {columns}"
+
+        image_presentation_time_seconds = mwkorks_df[ground_truth_time_column].values / 1e6
         stimuli_presented = mwkorks_df.stimulus_presented.values
 
         file_path_list = [self.stimuli_folder / f"{stimuli_number}.mp4" for stimuli_number in stimuli_presented]


### PR DESCRIPTION
This is a working script for converting the new data. The script convers the session data plus all the normalizer data that was collected on the same date.  In other words, running the added script will produce one nwb file for the data collected on that day plus other two nwbfiles, one for each of the two normalizers datasets. 

@yoonbai I also added other improvements that I think you should look into
* Corrected indexing issue on the video interface. Assumes 0 index for the stimuli name
* Added stub capabilities to the stimuli interface
* Exposed the parameter that determines which columns of the works csv is counted as the ground truth for time.
* Added session_id in line with your request on the meeting today.
* Changed "image_set_name" to "project_name"