### PR TITLE
Extract psth method from BinnedAlignedSpikes to DiCarlo format and write it to nwbfile

### DIFF
--- a/src/dicarlo_lab_to_nwb/conversion/behaviorinterface.py
+++ b/src/dicarlo_lab_to_nwb/conversion/behaviorinterface.py
@@ -23,7 +23,13 @@ class BehavioralTrialsInterface(BaseDataInterface):
 
         return metadata
 
-    def add_to_nwbfile(self, nwbfile: NWBFile, metadata: dict):
+    def add_to_nwbfile(
+        self,
+        nwbfile: NWBFile,
+        metadata: dict | None = None,
+        stub_test: bool = False,
+        ground_truth_time_column: str = "samp_on_us",
+    ):
         # In this experiment setup the presentation of stimuli is batched as groups of at most 8 images.
         # Every presentation starts with a stim_on_time, then up to 8 images are presented
         # for stim_on time, then there is a stim_off_time before the next presentation.
@@ -33,7 +39,9 @@ class BehavioralTrialsInterface(BaseDataInterface):
         dtype = {"stimulus_presented": np.uint32, "fixation_correct": bool}
         mwkorks_df = pd.read_csv(self.file_path, dtype=dtype)
 
-        ground_truth_time_column = "samp_on_us"
+        if stub_test:
+            mwkorks_df = mwkorks_df.iloc[:100]
+
         mwkorks_df["start_time"] = mwkorks_df[ground_truth_time_column] / 1e6
         mwkorks_df["stimuli_presentation_time_ms"] = mwkorks_df["stim_on_time_ms"]
         mwkorks_df["inter_stimuli_interval_ms"] = mwkorks_df["stim_off_time_ms"]

--- a/src/dicarlo_lab_to_nwb/conversion/conversion_sfm_videos_session.py
+++ b/src/dicarlo_lab_to_nwb/conversion/conversion_sfm_videos_session.py
@@ -21,6 +21,7 @@ add_thresholding_events = True
 add_psth = True
 stimuli_are_video = True
 add_raw_amplifier_data = False
+add_psth_in_pipeline_format_to_nwb = True
 
 thresholindg_pipeline_kwargs = {
     "f_notch": 60.0,  # Frequency for the notch filter
@@ -42,7 +43,8 @@ folders_in_session_date = [folder for folder in session_folder_path.iterdir() if
 session_data_folder_path = next(path for path in folders_in_session_date if project_name in path.name)
 normalizers = [folder for folder in folders_in_session_date if "normalizers" in folder.name]
 
-folder_paths_to_convert = [session_data_folder_path] + normalizers
+folder_paths_to_convert = normalizers
+folder_paths_to_convert += [session_data_folder_path]
 
 for folder_with_data_path in folder_paths_to_convert:
     intan_file_path = folder_with_data_path / "info.rhd"
@@ -81,4 +83,5 @@ for folder_with_data_path in folder_paths_to_convert:
         stimuli_are_video=stimuli_are_video,
         ground_truth_time_column=ground_truth_time_column,
         add_raw_amplifier_data=add_raw_amplifier_data,
+        add_psth_in_pipeline_format_to_nwb=add_psth_in_pipeline_format_to_nwb,
     )

--- a/src/dicarlo_lab_to_nwb/conversion/conversion_sfm_videos_session.py
+++ b/src/dicarlo_lab_to_nwb/conversion/conversion_sfm_videos_session.py
@@ -10,11 +10,12 @@ stimulus_data_folder_path = data_folder / project_name
 assert stimulus_data_folder_path.exists(), f"{stimulus_data_folder_path} does not exist"
 
 session_date = "20240715"
+session_date = "20240716"
 subject = "Apollo"  # Confirm this?
 pipeline_version = "DiLorean"
 
 output_dir_path = data_folder / "nwb_files"
-stub_test = True
+stub_test = False
 verbose = True
 add_thresholding_events = True
 add_psth = True

--- a/src/dicarlo_lab_to_nwb/conversion/convert_session.py
+++ b/src/dicarlo_lab_to_nwb/conversion/convert_session.py
@@ -18,7 +18,10 @@ from dicarlo_lab_to_nwb.conversion.probe import (
     UtahArrayProbeInterface,
     attach_probe_to_recording,
 )
-from dicarlo_lab_to_nwb.conversion.psth import write_binned_spikes_to_nwbfile
+from dicarlo_lab_to_nwb.conversion.psth import (
+    write_binned_spikes_to_nwbfile,
+    write_psth_pipeline_format_to_nwbfile,
+)
 from dicarlo_lab_to_nwb.conversion.stimuli_interface import (
     StimuliImagesInterface,
     StimuliVideoInterface,
@@ -41,6 +44,7 @@ def convert_session_to_nwb(
     ground_truth_time_column: str = "samp_on_us",
     add_raw_amplifier_data: bool = False,
     probe_info_path: str | Path | None = None,
+    add_psth_in_pipeline_format_to_nwb: bool = True,
 ):
     if verbose:
         total_start = time.time()
@@ -227,6 +231,12 @@ def convert_session_to_nwb(
             milliseconds_from_event_to_first_bin=milliseconds_from_event_to_first_bin,
             verbose=verbose,
         )
+
+        if add_psth_in_pipeline_format_to_nwb:
+            write_psth_pipeline_format_to_nwbfile(
+                nwbfile_path=nwbfile_path,
+                verbose=verbose,
+            )
 
         if verbose:
             stop_time = time.time()

--- a/src/dicarlo_lab_to_nwb/conversion/convert_session.py
+++ b/src/dicarlo_lab_to_nwb/conversion/convert_session.py
@@ -95,7 +95,7 @@ def convert_session_to_nwb(
 
     # Behavioral Trials Interface
     behavioral_trials_interface = BehavioralTrialsInterface(file_path=mworks_processed_file_path)
-
+    conversion_options["Behavior"] = dict(stub_test=stub_test, ground_truth_time_column=ground_truth_time_column)
     # Add Stimuli Interface
     if stimuli_are_video:
         stimuli_interface = StimuliVideoInterface(
@@ -194,7 +194,6 @@ def convert_session_to_nwb(
         nwbfile_path = write_thresholding_events_to_nwb(
             sorting=sorting,
             nwbfile_path=nwbfile_path,
-            append=True,
             verbose=verbose,
             thresholindg_pipeline_kwargs=thresholindg_pipeline_kwargs,
         )
@@ -226,7 +225,6 @@ def convert_session_to_nwb(
             bin_width_in_milliseconds=bin_width_in_milliseconds,
             number_of_bins=number_of_bins,
             milliseconds_from_event_to_first_bin=milliseconds_from_event_to_first_bin,
-            append=True,
             verbose=verbose,
         )
 
@@ -250,4 +248,4 @@ def convert_session_to_nwb(
         else:
             print(f"Total script took {total_scrip_time / 60 / 60:.2f} hours")
 
-        print("\n \n \n")
+        print("\n \n")

--- a/src/dicarlo_lab_to_nwb/conversion/convert_session.py
+++ b/src/dicarlo_lab_to_nwb/conversion/convert_session.py
@@ -202,6 +202,8 @@ def convert_session_to_nwb(
             thresholindg_pipeline_kwargs=thresholindg_pipeline_kwargs,
         )
 
+        del sorting
+
         if verbose:
             stop_time = time.time()
             thresholding_time = stop_time - start_time

--- a/src/dicarlo_lab_to_nwb/conversion/pipeline.py
+++ b/src/dicarlo_lab_to_nwb/conversion/pipeline.py
@@ -519,6 +519,7 @@ def calculate_thresholding_events(
 
         num_units = len(probe_sorting.get_unit_ids())
         values = [probe_name] * num_units
+        values = np.asarray(values, dtype=object)
         probe_sorting.set_property(key="probe", values=values)
         sorting_list.append(probe_sorting)
 
@@ -541,7 +542,7 @@ def write_thresholding_events_to_nwb(
     sorting: BaseSorting,
     nwbfile_path: str | Path,
     thresholindg_pipeline_kwargs: dict,
-    append=False,
+    append: bool = True,
     verbose: bool = False,
 ):
 
@@ -555,8 +556,16 @@ def write_thresholding_events_to_nwb(
             f"{thresholindg_pipeline_kwargs}"
         )
 
-        number_of_units = sorting.get_num_units()
-        unit_electrode_indices = [[i] for i in range(number_of_units)]
+        # We map the units to electrodes based on the unit name
+        # For the Utah Array probe there is only site per channel
+        unit_names = sorting.get_unit_ids()
+        channel_names = nwbfile.electrodes["channel_name"].data[:].tolist()
+
+        unit_electrode_indices = []
+        for unit_name in unit_names:
+            index = channel_names.index(unit_name)
+            unit_electrode_indices.append([index])
+
         add_sorting_to_nwbfile(
             nwbfile=nwbfile,
             sorting=sorting,

--- a/src/dicarlo_lab_to_nwb/conversion/psth.py
+++ b/src/dicarlo_lab_to_nwb/conversion/psth.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import natsort
 import numpy as np
 from ndx_binned_spikes import BinnedAlignedSpikes
 from pynwb import NWBHDF5IO, NWBFile
@@ -216,7 +217,7 @@ def build_psth_from_nwbfile(
     number_of_bins: int,
     milliseconds_from_event_to_first_bin: float = 0.0,
     verbose: bool = False,
-) -> tuple[dict, dict]:
+) -> tuple[dict, dict, list]:
     """
     Calculate peristimulus time histograms (PSTHs) for each stimulus from an NWB file.
 
@@ -235,11 +236,13 @@ def build_psth_from_nwbfile(
 
     Returns
     -------
-    psth_dict : dict
+    stimuli_id_psth : dict
         Dictionary where keys are stimulus IDs and values are arrays of PSTH counts.
-    stimuli_presentation_times_dict : dict
+    stimuli_id_times : dict
         Dictionary where keys are stimulus IDs and values are arrays of stimulus presentation times in seconds.
-
+    unit_ids_order: list
+        List of unit ids sorted by their name (A-001, A-002, ...). Used to build a map between the units
+        in the psth and the units in the NWB file.
     Raises
     ------
     AssertionError
@@ -249,29 +252,27 @@ def build_psth_from_nwbfile(
     units_data_frame = nwbfile.units.to_dataframe()
     unit_ids = units_data_frame["unit_name"].values
     spike_times = units_data_frame["spike_times"].values
+
     dict_of_spikes_times = {id: st for id, st in zip(unit_ids, spike_times)}
 
     # For the DiCarlo project it is important that units are sorted by their name (A-001, A-002, ...)
-    unit_ids_sorted = sorted(unit_ids)
-    spike_times_list = [dict_of_spikes_times[id] for id in unit_ids_sorted]
+    unit_ids_order = sorted(unit_ids)
+    spike_times_list = [dict_of_spikes_times[id] for id in unit_ids_order]
 
     trials_dataframe = nwbfile.trials.to_dataframe()
-    stimuli_presentation_times_seconds = trials_dataframe["start_time"]
+    stimuli_times = trials_dataframe["start_time"]  # In seconds
     stimuli_presentation_id = trials_dataframe["stimulus_presented"]
     stimuli_ids = stimuli_presentation_id.unique()
 
     # We also sort the stimuli by their id
     stimuli_ids_sorted = sorted(stimuli_ids)
+    id_to_df_indices = {id: stimuli_presentation_id == id for id in stimuli_ids_sorted}
+    stimuli_id_times = {id: stimuli_times[indices] for id, indices in id_to_df_indices.items()}
 
-    stimuli_presentation_times_dict = {
-        stimulus_id: stimuli_presentation_times_seconds[stimuli_presentation_id == stimulus_id].values
-        for stimulus_id in stimuli_ids_sorted
-    }
-
-    psth_dict = {}
+    stimuli_id_psth = {}
     desc = "Calculating PSTH for stimuli"
     for stimuli_id in tqdm(stimuli_ids_sorted, desc=desc, unit=" stimuli processed", disable=not verbose):
-        stimulus_presentation_times = stimuli_presentation_times_dict[stimuli_id]
+        stimulus_presentation_times = stimuli_id_times[stimuli_id]
         psth_per_stimuli = calculate_event_psth(
             spike_times_list=spike_times_list,
             event_times_seconds=stimulus_presentation_times,
@@ -279,9 +280,9 @@ def build_psth_from_nwbfile(
             number_of_bins=number_of_bins,
             milliseconds_from_event_to_first_bin=milliseconds_from_event_to_first_bin,
         )
-        psth_dict[stimuli_id] = psth_per_stimuli
+        stimuli_id_psth[stimuli_id] = psth_per_stimuli
 
-    return psth_dict, stimuli_presentation_times_dict
+    return stimuli_id_psth, stimuli_id_times, unit_ids_order
 
 
 def build_binned_aligned_spikes_from_nwbfile(
@@ -316,7 +317,7 @@ def build_binned_aligned_spikes_from_nwbfile(
 
     assert nwbfile.units is not None, "NWBFile does not have units table, psths cannot be calculated."
 
-    psth_dict, stimuli_presentation_times_dict = build_psth_from_nwbfile(
+    stimuli_id_psth, stimuli_id_times, unit_ids_order = build_psth_from_nwbfile(
         nwbfile=nwbfile,
         bin_width_in_milliseconds=bin_width_in_milliseconds,
         number_of_bins=number_of_bins,
@@ -325,23 +326,29 @@ def build_binned_aligned_spikes_from_nwbfile(
     )
 
     units_table = nwbfile.units
-    num_units = units_table["id"].shape[0]
-    region_indices = [i for i in range(num_units)]
+
+    # This guarantees that we link the unit to the corresponding psth in the
+    # way that they were sorted in the psth calculation
+    region_indices = []
+    unit_names = units_table["unit_name"].data[:].tolist()
+    for id in unit_ids_order:
+        index = unit_names.index(id)
+        region_indices.append(index)
+
     units_region = DynamicTableRegion(
         data=region_indices, table=units_table, description="region of units table", name="units_region"
     )
 
-    event_timestamps = [stimuli_presentation_times_dict[stimulus_id] for stimulus_id in psth_dict.keys()]
-    data = [psth_dict[stimulus_id] for stimulus_id in psth_dict.keys()]
-    condition_labels = [stimulus_id for stimulus_id in psth_dict.keys()]
-    condition_indices = [
-        [index] * len(stimuli_presentation_times_dict[stimulus_id])
-        for index, stimulus_id in enumerate(psth_dict.keys())
-    ]
+    event_timestamps = [stimuli_id_times[id] for id in stimuli_id_psth.keys()]
+    data = [stimuli_id_psth[id] for id in stimuli_id_psth.keys()]
+    condition_labels = [id for id in stimuli_id_psth.keys()]
+    condition_indices = [[index] * len(stimuli_id_times[id]) for index, id in enumerate(stimuli_id_psth.keys())]
 
     event_timestamps = np.concatenate(event_timestamps)
     data = np.concatenate(data, axis=1)  # We concatenate across the events axis
+    data = data.astype("uint64")
     condition_indices = np.concatenate(condition_indices)
+    condition_indices = condition_indices.astype("uint64")
 
     data, event_timestamps, condition_indices = BinnedAlignedSpikes.sort_data_by_event_timestamps(
         data=data,
@@ -353,6 +360,7 @@ def build_binned_aligned_spikes_from_nwbfile(
         name=f"BinnedAlignedSpikesToStimulus",
         data=data,
         event_timestamps=event_timestamps,
+        condition_indices=condition_indices,
         condition_labels=condition_labels,
         bin_width_in_milliseconds=bin_width_in_milliseconds,
         milliseconds_from_event_to_first_bin=milliseconds_from_event_to_first_bin,
@@ -367,7 +375,7 @@ def write_binned_spikes_to_nwbfile(
     number_of_bins: int,
     bin_width_in_milliseconds: float,
     milliseconds_from_event_to_first_bin: float = 0.0,
-    append: bool = False,
+    append: bool = True,
     verbose: bool = False,
 ) -> Path | str:
     """
@@ -426,3 +434,122 @@ def write_binned_spikes_to_nwbfile(
     if verbose:
         print(f"Appended binned spikes to {nwbfile_path}")
     return nwbfile_path
+
+
+from ndx_binned_spikes import BinnedAlignedSpikes
+
+
+def reshape_binned_spikes_data_to_pipeline_format(binned_aligned_spikes: BinnedAlignedSpikes) -> np.ndarray:
+    """
+    Extracts the PSTH data from the BinnedAlignedSpikes object and reshapes it to the DiCarlo lab convention.
+
+    Reorganizes spike data from (units, stimuli, bins) format to
+    (units, stimuli_index, stimuli_repetitions, time_bins) format, with stimuli ordered by
+    naturally sorted condition labels. Empty repetitions are filled with NaN values.
+
+    Parameters
+    ----------
+    binned_aligned_spikes : BinnedAlignedSpikes
+        Object containing aligned spike data with conditions and labels. Must have attributes:
+        - data : array of spike counts
+        - condition_indices : indices mapping trials to conditions
+        - condition_labels : labels for each condition
+        - number_of_units : total number of units
+        - number_of_bins : number of time bins
+        - number_of_conditions : number of unique stimuli
+
+    see `ndx-binned-spikes` for more information on the BinnedAlignedSpikes object.
+
+    Returns
+    -------
+    np.ndarray
+        Reshaped array with dimensions (units, stimuli_index, stimuli_repetitions, time_bins).
+        The stimuli are ordered according to natural sorting of their condition labels.
+        Missing repetitions are filled with NaN values.
+
+    Notes
+    -----
+    The function uses natural sorting for condition labels, meaning that labels like
+    ['stim1', 'stim2', 'stim10'] will be correctly ordered numerically instead of
+    lexicographically. Empty repetition slots are filled with NaN to maintain consistent
+    array dimensions across all stimuli.
+    """
+    import ndx_binned_spikes
+
+    data = binned_aligned_spikes.data[:]
+    condition_indices = binned_aligned_spikes.condition_indices[:]
+    condition_labels = binned_aligned_spikes.condition_labels[:]
+
+    number_of_units = binned_aligned_spikes.number_of_units
+    number_of_bins = binned_aligned_spikes.number_of_bins
+    number_of_stimuli = binned_aligned_spikes.number_of_conditions
+
+    unique_conditions = np.unique(condition_indices)
+    max_repetitions = max(np.sum(condition_indices == cond) for cond in unique_conditions)
+
+    psth_pipepline_format = np.full((number_of_units, number_of_stimuli, max_repetitions, number_of_bins), np.nan)
+
+    # Now, we will fill the data in the ordered of the sorted condition labels
+    stimuli_labels_order = natsort.natsorted(condition_labels)
+
+    for stimulus_index, label in enumerate(stimuli_labels_order):
+
+        # Find corresponding condition index
+        condition_index = np.where(condition_labels == label)[0][0]
+        stimulus_psth = binned_aligned_spikes.get_data_for_condition(condition_index=condition_index)
+        n_reps = stimulus_psth.shape[1]
+
+        # Directly index the data using the condition trials
+        psth_pipepline_format[:, stimulus_index, :n_reps, :] = stimulus_psth
+
+    return psth_pipepline_format
+
+
+def extract_psth_pipeline_format_from_nwbpath(
+    nwbfile_path: str | Path,
+    binned_aligned_spikes_name: str | None = None,
+) -> np.ndarray:
+    """
+    Extracts the PSTH data from the BinnedAlignedSpikes object and reshapes it to the DiCarlo lab convention.
+
+    Reorganizes spike data from (units, stimuli, bins) format to
+    (units, stimuli_index, stimuli_repetitions, time_bins) format, with stimuli ordered by
+    naturally sorted condition labels. Empty repetitions are filled with NaN values.
+
+    Parameters
+    ----------
+    binned_aligned_spikes : BinnedAlignedSpikes
+        Object containing aligned spike data with conditions and labels. Must have attributes:
+        - data : array of spike counts
+        - condition_indices : indices mapping trials to conditions
+        - condition_labels : labels for each condition
+        - number_of_units : total number of units
+        - number_of_bins : number of time bins
+        - number_of_conditions : number of unique stimuli
+
+    Returns
+    -------
+    np.ndarray
+        Reshaped array with dimensions (units, stimuli_index, stimuli_repetitions, time_bins).
+        The stimuli are ordered according to natural sorting of their condition labels.
+        Missing repetitions are filled with NaN values.
+
+    Notes
+    -----
+    The function uses natural sorting for condition labels, meaning that labels like
+    ['stim1', 'stim2', 'stim10'] will be correctly ordered numerically instead of
+    lexicographically. Empty repetition slots are filled with NaN to maintain consistent
+    array dimensions across all stimuli.
+    """
+
+    import ndx_binned_spikes  # This is necessary to avoid some pynwb extensio bug where methods are not loaded
+    from pynwb import NWBHDF5IO
+
+    binned_aligned_spikes_name = binned_aligned_spikes_name or "BinnedAlignedSpikesToStimulus"
+
+    with NWBHDF5IO(nwbfile_path, mode="r") as io:
+        nwbfile = io.read()
+        binned_aligned_spikes = nwbfile.processing["ecephys"][binned_aligned_spikes_name]
+        psth_pipeline_format = reshape_binned_spikes_data_to_pipeline_format(binned_aligned_spikes)
+
+    return psth_pipeline_format

--- a/src/dicarlo_lab_to_nwb/conversion/stimuli_interface.py
+++ b/src/dicarlo_lab_to_nwb/conversion/stimuli_interface.py
@@ -52,7 +52,7 @@ class StimuliImagesInterface(BaseDataInterface):
         mwkorks_df = pd.read_csv(self.file_path, dtype=dtype)
 
         if stub_test:
-            mwkorks_df = mwkorks_df.iloc[:100]
+            mwkorks_df = mwkorks_df.iloc[:10]
 
         columns = mwkorks_df.columns
         assert ground_truth_time_column in columns, f"Column {ground_truth_time_column} not found in {columns}"
@@ -135,7 +135,7 @@ class StimuliVideoInterface(BaseDataInterface):
     def add_to_nwbfile(
         self,
         nwbfile: NWBFile,
-        metadata: dict,
+        metadata: dict | None = None,
         stub_test: bool = False,
         ground_truth_time_column: str = "samp_on_us",
     ):
@@ -143,7 +143,7 @@ class StimuliVideoInterface(BaseDataInterface):
         mwkorks_df = pd.read_csv(self.file_path, dtype=dtype)
 
         if stub_test:
-            mwkorks_df = mwkorks_df.iloc[:100]
+            mwkorks_df = mwkorks_df.iloc[:10]
 
         columns = mwkorks_df.columns
         assert ground_truth_time_column in columns, f"Column {ground_truth_time_column} not found in {columns}"


### PR DESCRIPTION
This PR adds a method for transforming the BinnedAlignedSpikeTimes to the DiCarlo convention plus the capability of adding it to the nwbfile.

It also adds stubbing capabilities to the Behavior interface to streamline testing and fixes the missing condition indices on the PSTH object.